### PR TITLE
Копирование параметров: Использование спецификаций

### DIFF
--- a/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
+++ b/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using Autodesk.Revit.ApplicationServices;
 using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
 
 using dosymep.Bim4Everyone;
 using dosymep.Bim4Everyone.KeySchedules;
@@ -20,6 +21,8 @@ namespace dosymep.Bim4Everyone.Templates {
     /// Класс по копирование параметров проекта.
     /// </summary>
     public class ProjectParameters {
+        private const string ParameterTransferScheduleNamePrefix = "BIM4E_PARAM_TRANSFER_";
+
         private readonly ILoggerService _loggerService;
 
         /// <summary>
@@ -304,7 +307,12 @@ namespace dosymep.Bim4Everyone.Templates {
                 return false;
             }
 
-            ICollection<ElementId> copiedElements = ElementTransformUtils.CopyElements(source, new[] { viewSchedule.Id }, target, Transform.Identity, new CopyPasteOptions());
+            ICollection<ElementId> copiedElements = ElementTransformUtils.CopyElements(
+                source,
+                new[] { viewSchedule.Id },
+                target,
+                Transform.Identity,
+                CreateCopyPasteOptions());
             if(removeSchedule) {
                 // Удаляем скопированный вид,
                 // так как он нужен был для переноса параметра
@@ -332,7 +340,12 @@ namespace dosymep.Bim4Everyone.Templates {
                 return false;
             }
 
-            ICollection<ElementId> copiedElements = ElementTransformUtils.CopyElements(source, viewSchedules.Select(item => item.Id).ToArray(), target, Transform.Identity, new CopyPasteOptions());
+            ICollection<ElementId> copiedElements = ElementTransformUtils.CopyElements(
+                source,
+                viewSchedules.Select(item => item.Id).ToArray(),
+                target,
+                Transform.Identity,
+                CreateCopyPasteOptions());
             if(removeSchedule) {
                 // Удаляем скопированные виды,
                 // так как они нужны были для переноса параметра
@@ -357,7 +370,10 @@ namespace dosymep.Bim4Everyone.Templates {
         private void RevitParamsCopy(Document target, IEnumerable<RevitParam> revitParams) {
             Document source = Application.OpenDocumentFile(ModuleEnvironment.ParametersTemplatePath);
             try {
+                ICollection<ViewSchedule> transferSchedules = CreateParameterTransferSchedules(source, target, revitParams);
+
                 using(var transaction = target.StartTransaction("Настройка параметров")) {
+                    CopyViewSchedules(source, target, true, transferSchedules);
                     RevitParamsSync(source, target, revitParams);
                     RevitParamsCopy(source, target, revitParams);
 
@@ -366,6 +382,187 @@ namespace dosymep.Bim4Everyone.Templates {
             } finally {
                 source.Close(false);
             }
+        }
+
+        /// <summary>
+        /// Создает трансферные таблицы для отсутствующих в целевом документе параметров.
+        /// </summary>
+        /// <param name="source">Шаблон</param>
+        /// <param name="target">Целевой документ</param>
+        /// <param name="revitParams">Параметры, которые нужно проверить на наличие в целевом документе</param>
+        /// <returns></returns>
+        private ICollection<ViewSchedule> CreateParameterTransferSchedules(
+            Document source,
+            Document target,
+            IEnumerable<RevitParam> revitParams) {
+            RevitParam[] missingParams = revitParams
+                .Where(item => !item.IsExistsParam(target))
+                .ToArray();
+
+            if(missingParams.Length == 0) {
+                return Array.Empty<ViewSchedule>();
+            }
+
+            var transferSchedules = new List<ViewSchedule>();
+            var transferSchedulesByCategoryId = new Dictionary<long, ViewSchedule>();
+
+            using(var transaction = source.StartTransaction("Создание временных спецификаций параметров")) {
+                foreach(RevitParam revitParam in missingParams) {
+                    try {
+                        ParameterElement parameterElement = revitParam.GetRevitParamElement(source);
+                        if(parameterElement == null) {
+                            continue;
+                        }
+
+                        ViewSchedule viewSchedule = CreateParameterTransferSchedule(
+                            source,
+                            transferSchedulesByCategoryId,
+                            revitParam,
+                            parameterElement);
+                        
+                        if(viewSchedule != null
+                           && !transferSchedules.Any(item => item.Id == viewSchedule.Id)) {
+                            transferSchedules.Add(viewSchedule);
+                        }
+
+                        if(viewSchedule == null) {
+                            _loggerService.Warning(
+                                "Не удалось создать временную спецификацию переноса для параметра {@revitParam} в шаблоне.",
+                                revitParam);
+                        }
+                    } catch(Exception ex) {
+                        _loggerService.Warning(
+                            ex,
+                            "Не удалось подготовить временную спецификацию переноса для параметра {@revitParam} в шаблоне.",
+                            revitParam);
+                    }
+                }
+
+                transaction.Commit();
+            }
+
+            return transferSchedules;
+        }
+
+        /// <summary>
+        /// Создает временную спецификацию переноса для параметра в шаблоне или использует одну из ранее созданных.
+        /// </summary>
+        /// <param name="source">Файл шаблона</param>
+        /// <param name="transferSchedulesByCategoryId">Словарь ранее созданных спецификаций</param>
+        /// <param name="revitParam">Параметр</param>
+        /// <param name="parameterElement">Объект параметра из шаблона</param>
+        /// <returns></returns>
+        private ViewSchedule CreateParameterTransferSchedule(
+            Document source,
+            IDictionary<long, ViewSchedule> transferSchedulesByCategoryId,
+            RevitParam revitParam,
+            ParameterElement parameterElement) {
+            foreach(Category category in GetRevitParamCategories(source, revitParam)) {
+                ViewSchedule viewSchedule = GetOrCreateParameterTransferSchedule(
+                    source,
+                    transferSchedulesByCategoryId,
+                    category);
+                if(viewSchedule == null) {
+                    continue;
+                }
+
+                if(TryAddParameterTransferField(viewSchedule, parameterElement)) {
+                    return viewSchedule;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Создает новую трансферную спецификацию или возвращает ранее созданную для текущей категории.
+        /// </summary>
+        /// <param name="source">Файл шаблона</param>
+        /// <param name="transferSchedulesByCategoryId">Словарь с трансферными спецификацями</param>
+        /// <param name="category">Категория</param>
+        /// <returns></returns>
+        private ViewSchedule GetOrCreateParameterTransferSchedule(
+            Document source,
+            IDictionary<long, ViewSchedule> transferSchedulesByCategoryId,
+            Category category) {
+            long categoryId = category.Id.GetIdValue();
+            if(transferSchedulesByCategoryId.TryGetValue(categoryId, out ViewSchedule viewSchedule)) {
+                return viewSchedule;
+            }
+
+            try {
+                viewSchedule = ViewSchedule.CreateSchedule(source, category.Id);
+                viewSchedule.Name = $"{ParameterTransferScheduleNamePrefix}{Guid.NewGuid():N}";
+                transferSchedulesByCategoryId.Add(categoryId, viewSchedule);
+
+                return viewSchedule;
+            } catch(Exception ex) {
+                transferSchedulesByCategoryId.Add(categoryId, null);
+                _loggerService.Warning(
+                    ex,
+                    "Не удалось создать временную спецификацию переноса для категории {category} в шаблоне.",
+                    category.Name);
+
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Возвращает категории, к которым привязан параметр в файле шаблона.
+        /// </summary>
+        /// <param name="source">Файл шаблона</param>
+        /// <param name="revitParam">Параметр</param>
+        /// <returns></returns>
+        private static IEnumerable<Category> GetRevitParamCategories(Document source, RevitParam revitParam) {
+            (Definition Definition, Binding Binding) paramBinding = revitParam.GetParamBinding(source);
+            if(!(paramBinding.Binding is ElementBinding elementBinding)) {
+                yield break;
+            }
+
+            foreach(Category category in elementBinding.Categories) {
+                if(category != null) {
+                    yield return category;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Пробует добавить в трансферную спецификацию требуемый параметр. Если в ранее созданной таблице уже есть такой параметр, возвращает True и не добавляет.
+        /// </summary>
+        /// <param name="viewSchedule">Таблица</param>
+        /// <param name="parameterElement">Объект параметра из шаблона</param>
+        /// <returns></returns>
+        private static bool TryAddParameterTransferField(ViewSchedule viewSchedule, ParameterElement parameterElement) {
+            if(IsParameterTransferFieldExists(viewSchedule, parameterElement)) {
+                return true;
+            }
+
+            SchedulableField schedulableField = viewSchedule.Definition
+                .GetSchedulableFields()
+                .FirstOrDefault(item => item.ParameterId == parameterElement.Id);
+            if(schedulableField == null) {
+                return false;
+            }
+
+            try {
+                viewSchedule.Definition.AddField(schedulableField);
+                return true;
+            } catch(Exception) {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Для ранее созданной таблицы проверяет существует ли в ней уже требуемый параметр.
+        /// </summary>
+        /// <param name="viewSchedule">Таблица</param>
+        /// <param name="parameterElement">Объект параметра из шаблона</param>
+        /// <returns></returns>
+        private static bool IsParameterTransferFieldExists(ViewSchedule viewSchedule, ParameterElement parameterElement) {
+            ScheduleDefinition definition = viewSchedule.Definition;
+            return definition.GetFieldOrder()
+                .Select(item => definition.GetField(item))
+                .Any(item => item.ParameterId == parameterElement.Id);
         }
 
         private void RevitParamsCopy(Document source, Document target, IEnumerable<RevitParam> revitParams) {
@@ -435,6 +632,31 @@ namespace dosymep.Bim4Everyone.Templates {
             // Удаляем все найденные настройки организации браузера
             // чтобы произвести замену этих элементов
             target.Delete(removingElements);
+        }
+
+        /// <summary>
+        /// Создает настройки копирования элементов.
+        /// </summary>
+        /// <returns>Возвращает настройки копирования элементов.</returns>
+        private static CopyPasteOptions CreateCopyPasteOptions() {
+            var copyPasteOptions = new CopyPasteOptions();
+            copyPasteOptions.SetDuplicateTypeNamesHandler(new UseDestinationDuplicateTypeNamesHandler());
+
+            return copyPasteOptions;
+        }
+
+        /// <summary>
+        /// Обработчик совпадений имен типов при копировании элементов.
+        /// </summary>
+        private class UseDestinationDuplicateTypeNamesHandler : IDuplicateTypeNamesHandler {
+            /// <summary>
+            /// Обрабатывает совпадения имен типов при копировании элементов.
+            /// </summary>
+            /// <param name="args">Аргументы обработчика совпадений имен типов.</param>
+            /// <returns>Возвращает действие для обработки совпадающих типов.</returns>
+            public DuplicateTypeAction OnDuplicateTypeNamesFound(DuplicateTypeNamesHandlerArgs args) {
+                return DuplicateTypeAction.UseDestinationTypes;
+            }
         }
     }
 }

--- a/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
+++ b/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 
 using Autodesk.Revit.ApplicationServices;
 using Autodesk.Revit.DB;
-using Autodesk.Revit.UI;
 
 using dosymep.Bim4Everyone;
 using dosymep.Bim4Everyone.KeySchedules;

--- a/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
+++ b/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
@@ -365,25 +365,6 @@ namespace dosymep.Bim4Everyone.Templates {
             target.Delete(viewSchedules.Select(item => item.Id).ToArray());
         }
 
-        #endregion
-        
-        private void RevitParamsCopy(Document target, IEnumerable<RevitParam> revitParams) {
-            Document source = Application.OpenDocumentFile(ModuleEnvironment.ParametersTemplatePath);
-            try {
-                ICollection<ViewSchedule> transferSchedules = CreateParameterTransferSchedules(source, target, revitParams);
-
-                using(var transaction = target.StartTransaction("Настройка параметров")) {
-                    CopyViewSchedules(source, target, true, transferSchedules);
-                    RevitParamsSync(source, target, revitParams);
-                    RevitParamsCopy(source, target, revitParams);
-
-                    transaction.Commit();
-                }
-            } finally {
-                source.Close(false);
-            }
-        }
-
         /// <summary>
         /// Создает трансферные таблицы для отсутствующих в целевом документе параметров.
         /// </summary>
@@ -563,6 +544,25 @@ namespace dosymep.Bim4Everyone.Templates {
             return definition.GetFieldOrder()
                 .Select(item => definition.GetField(item))
                 .Any(item => item.ParameterId == parameterElement.Id);
+        }
+
+        #endregion
+        
+        private void RevitParamsCopy(Document target, IEnumerable<RevitParam> revitParams) {
+            Document source = Application.OpenDocumentFile(ModuleEnvironment.ParametersTemplatePath);
+            try {
+                ICollection<ViewSchedule> transferSchedules = CreateParameterTransferSchedules(source, target, revitParams);
+
+                using(var transaction = target.StartTransaction("Настройка параметров")) {
+                    CopyViewSchedules(source, target, true, transferSchedules);
+                    RevitParamsSync(source, target, revitParams);
+                    RevitParamsCopy(source, target, revitParams);
+
+                    transaction.Commit();
+                }
+            } finally {
+                source.Close(false);
+            }
         }
 
         private void RevitParamsCopy(Document source, Document target, IEnumerable<RevitParam> revitParams) {

--- a/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
+++ b/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Windows;
 
 using Autodesk.Revit.DB;
 
@@ -417,7 +416,7 @@ namespace dosymep.Bim4Everyone.Templates {
         /// <param name="source">Документ с параметрами.</param>
         /// <param name="revitParams">Параметры.</param>
         /// <returns>Возвращает элементы параметров.</returns>
-        private static ParameterElement[] GetRevitParamElements(Document source, IEnumerable<RevitParam> revitParams) {
+        private ParameterElement[] GetRevitParamElements(Document source, IEnumerable<RevitParam> revitParams) {
             return revitParams
                 .Select(item => item.GetRevitParamElement(source))
                 .Where(item => item != null)
@@ -430,7 +429,7 @@ namespace dosymep.Bim4Everyone.Templates {
         /// <param name="target">Целевой документ.</param>
         /// <param name="revitParams">Параметры, которые нужно разделить.</param>
         /// <returns>Возвращает отсутствующие параметры и параметры без привязки.</returns>
-        private static (
+        private (
             ICollection<RevitParam> MissingParams,
             ICollection<RevitParam> ParamsWithoutBinding) SplitRevitParamsByBinding(
                 Document target,
@@ -460,7 +459,7 @@ namespace dosymep.Bim4Everyone.Templates {
         /// <param name="document">Документ.</param>
         /// <param name="revitParam">Общий параметр.</param>
         /// <returns>Возвращает элемент общего параметра.</returns>
-        private static ParameterElement GetRevitSharedParamElement(Document document, RevitParam revitParam) {
+        private ParameterElement GetRevitSharedParamElement(Document document, RevitParam revitParam) {
             if(!(revitParam is SharedParam sharedParam)) {
                 return null;
             }
@@ -477,7 +476,7 @@ namespace dosymep.Bim4Everyone.Templates {
         /// <param name="source">Файл шаблона.</param>
         /// <param name="target">Целевой документ.</param>
         /// <param name="paramsElements">Параметры из шаблона.</param>
-        private static void CopyParamsByMultiCategorySchedule(
+        private void CopyParamsByMultiCategorySchedule(
             Document source,
             Document target,
             IEnumerable<ParameterElement> paramsElements) {
@@ -509,7 +508,7 @@ namespace dosymep.Bim4Everyone.Templates {
         /// Создает настройки копирования элементов.
         /// </summary>
         /// <returns>Возвращает настройки копирования элементов.</returns>
-        private static CopyPasteOptions CreateCopyPasteOptions() {
+        private CopyPasteOptions CreateCopyPasteOptions() {
             var copyPasteOptions = new CopyPasteOptions();
             copyPasteOptions.SetDuplicateTypeNamesHandler(new UseDestinationDuplicateTypeNamesHandler());
 

--- a/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
+++ b/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
@@ -378,17 +378,17 @@ namespace dosymep.Bim4Everyone.Templates {
             var paramsByCategory = new Dictionary<Category, List<ParameterElement>>();
             foreach(RevitParam revitParam in revitParams.Where(item => !item.IsExistsParam(target))) {
                 Category category = GetRevitParamCategory(source, revitParam);
-                ParameterElement parameterElement = revitParam.GetRevitParamElement(source);
-                if(category == null || parameterElement == null) {
+                ParameterElement param = revitParam.GetRevitParamElement(source);
+                if(category == null || param == null) {
                     continue;
                 }
 
-                if(!paramsByCategory.TryGetValue(category, out List<ParameterElement> parameterElements)) {
-                    parameterElements = new List<ParameterElement>();
-                    paramsByCategory.Add(category, parameterElements);
+                if(!paramsByCategory.TryGetValue(category, out List<ParameterElement> paramElements)) {
+                    paramElements = new List<ParameterElement>();
+                    paramsByCategory.Add(category, paramElements);
                 }
 
-                parameterElements.Add(parameterElement);
+                paramElements.Add(param);
             }
 
             if(paramsByCategory.Count == 0) {
@@ -425,19 +425,19 @@ namespace dosymep.Bim4Everyone.Templates {
         /// </summary>
         /// <param name="source">Файл шаблона</param>
         /// <param name="category">Категория</param>
-        /// <param name="parameterElements">Объекты параметров из шаблона</param>
+        /// <param name="paramElements">Объекты параметров из шаблона</param>
         /// <returns></returns>
         private ViewSchedule CreateParameterTransferSchedule(
             Document source,
             Category category,
-            IEnumerable<ParameterElement> parameterElements) {
+            IEnumerable<ParameterElement> paramElements) {
             ViewSchedule viewSchedule = ViewSchedule.CreateSchedule(source, category.Id);
             viewSchedule.Name = $"{ParameterTransferScheduleNamePrefix}{Guid.NewGuid():N}";
 
-            foreach(ParameterElement parameterElement in parameterElements) {
+            foreach(ParameterElement param in paramElements) {
                 SchedulableField schedulableField = viewSchedule.Definition
                     .GetSchedulableFields()
-                    .First(item => item.ParameterId == parameterElement.Id);
+                    .First(item => item.ParameterId == param.Id);
                 viewSchedule.Definition.AddField(schedulableField);
             }
 

--- a/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
+++ b/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
@@ -20,8 +20,6 @@ namespace dosymep.Bim4Everyone.Templates {
     /// Класс по копирование параметров проекта.
     /// </summary>
     public class ProjectParameters {
-        private const string ParamTransferScheduleNamePrefix = "BIM4E_PARAM_TRANSFER_";
-
         private readonly ILoggerService _loggerService;
 
         /// <summary>
@@ -306,12 +304,7 @@ namespace dosymep.Bim4Everyone.Templates {
                 return false;
             }
 
-            ICollection<ElementId> copiedElements = ElementTransformUtils.CopyElements(
-                source,
-                new[] { viewSchedule.Id },
-                target,
-                Transform.Identity,
-                CreateCopyPasteOptions());
+            ICollection<ElementId> copiedElements = ElementTransformUtils.CopyElements(source, new[] { viewSchedule.Id }, target, Transform.Identity, new CopyPasteOptions());
             if(removeSchedule) {
                 // Удаляем скопированный вид,
                 // так как он нужен был для переноса параметра
@@ -339,12 +332,7 @@ namespace dosymep.Bim4Everyone.Templates {
                 return false;
             }
 
-            ICollection<ElementId> copiedElements = ElementTransformUtils.CopyElements(
-                source,
-                viewSchedules.Select(item => item.Id).ToArray(),
-                target,
-                Transform.Identity,
-                CreateCopyPasteOptions());
+            ICollection<ElementId> copiedElements = ElementTransformUtils.CopyElements(source, viewSchedules.Select(item => item.Id).ToArray(), target, Transform.Identity, new CopyPasteOptions());
             if(removeSchedule) {
                 // Удаляем скопированные виды,
                 // так как они нужны были для переноса параметра
@@ -364,123 +352,12 @@ namespace dosymep.Bim4Everyone.Templates {
             target.Delete(viewSchedules.Select(item => item.Id).ToArray());
         }
 
-        /// <summary>
-        /// Создает трансферные таблицы для отсутствующих в целевом документе параметров.
-        /// </summary>
-        /// <param name="source">Шаблон</param>
-        /// <param name="target">Целевой документ</param>
-        /// <param name="revitParams">Параметры, которые нужно проверить на наличие в целевом документе</param>
-        /// <returns></returns>
-        private ICollection<ViewSchedule> CreateParamTransferSchedules(
-            Document source,
-            Document target,
-            IEnumerable<RevitParam> revitParams) {
-            var paramsByCategory = revitParams
-                .Where(revitParam => !revitParam.IsExistsParam(target))
-                .Select(revitParam => {
-                    ParameterElement param = revitParam.GetRevitParamElement(source);
-                    if(param == null) {
-                        throw new InvalidOperationException(
-                            $"Не удалось найти параметр '{revitParam.Name}' в шаблоне.");
-                    }
-
-                    return new {
-                        Category = GetRevitParamCategory(source, revitParam),
-                        RevitParam = revitParam,
-                        Param = param
-                    };
-                })
-                .Where(item => item.Param != null)
-                .GroupBy(item => item.Category.Id.GetIdValue())
-                .ToArray();
-
-            if(paramsByCategory.Length == 0) {
-                return Array.Empty<ViewSchedule>();
-            } 
-
-            var transferSchedules = new List<ViewSchedule>();
-
-            using(var transaction = source.StartTransaction("Создание временных спецификаций параметров")) {
-                Exception exception = null;
-                string paramName = null;
-                foreach(var paramsGroup in paramsByCategory) {
-                    Category category = paramsGroup.First().Category;
-                    try {
-                        ViewSchedule viewSchedule = CreateParamTransferSchedule(
-                            source,
-                            category,
-                            paramsGroup.Select(item => item.Param));
-                        
-                        transferSchedules.Add(viewSchedule);
-                    } catch(Exception ex) {
-                        exception = exception ?? ex;
-                        paramName = paramName ?? paramsGroup.First().RevitParam.Name;
-                    }
-                }
-
-                if(exception != null && transferSchedules.Count == 0) {
-                    throw new InvalidOperationException(
-                        $"Не удалось подготовить временную спецификацию переноса для параметра " +
-                        $"'{paramName}' в шаблоне.",
-                        exception);
-                }
-
-                transaction.Commit();
-            }
-
-            return transferSchedules;
-        }
-
-        /// <summary>
-        /// Создает временную спецификацию переноса для параметров в шаблоне.
-        /// </summary>
-        /// <param name="source">Файл шаблона</param>
-        /// <param name="category">Категория</param>
-        /// <param name="paramsElements">Параметры из шаблона</param>
-        /// <returns></returns>
-        private ViewSchedule CreateParamTransferSchedule(
-            Document source,
-            Category category,
-            IEnumerable<ParameterElement> paramsElements) {
-            ViewSchedule viewSchedule = ViewSchedule.CreateSchedule(source, category.Id);
-            viewSchedule.Name = $"{ParamTransferScheduleNamePrefix}{Guid.NewGuid():N}";
-
-            foreach(ParameterElement param in paramsElements) {
-                SchedulableField schedulableField = viewSchedule.Definition
-                    .GetSchedulableFields()
-                    .First(item => item.ParameterId == param.Id);
-                viewSchedule.Definition.AddField(schedulableField);
-            }
-
-            return viewSchedule;
-        }
-
-        /// <summary>
-        /// Возвращает категорию, к которой привязан параметр в файле шаблона.
-        /// </summary>
-        /// <param name="source">Файл шаблона</param>
-        /// <param name="param">Параметр</param>
-        /// <returns></returns>
-        private static Category GetRevitParamCategory(Document source, RevitParam param) {
-            (Definition Definition, Binding Binding) paramBinding = param.GetParamBinding(source);
-            if(!(paramBinding.Binding is ElementBinding elementBinding)) {
-                return null;
-            }
-
-            return elementBinding.Categories
-                .OfType<Category>()
-                .FirstOrDefault();
-        }
-
         #endregion
         
         private void RevitParamsCopy(Document target, IEnumerable<RevitParam> revitParams) {
             Document source = Application.OpenDocumentFile(ModuleEnvironment.ParametersTemplatePath);
             try {
-                ICollection<ViewSchedule> transferSchedules = CreateParamTransferSchedules(source, target, revitParams);
-
                 using(var transaction = target.StartTransaction("Настройка параметров")) {
-                    CopyViewSchedules(source, target, true, transferSchedules);
                     RevitParamsSync(source, target, revitParams);
                     RevitParamsCopy(source, target, revitParams);
 
@@ -558,31 +435,6 @@ namespace dosymep.Bim4Everyone.Templates {
             // Удаляем все найденные настройки организации браузера
             // чтобы произвести замену этих элементов
             target.Delete(removingElements);
-        }
-
-        /// <summary>
-        /// Создает настройки копирования элементов.
-        /// </summary>
-        /// <returns>Возвращает настройки копирования элементов.</returns>
-        private static CopyPasteOptions CreateCopyPasteOptions() {
-            var copyPasteOptions = new CopyPasteOptions();
-            copyPasteOptions.SetDuplicateTypeNamesHandler(new UseDestinationDuplicateTypeNamesHandler());
-
-            return copyPasteOptions;
-        }
-
-        /// <summary>
-        /// Обработчик совпадений имен типов при копировании элементов.
-        /// </summary>
-        private class UseDestinationDuplicateTypeNamesHandler : IDuplicateTypeNamesHandler {
-            /// <summary>
-            /// Обрабатывает совпадения имен типов при копировании элементов.
-            /// </summary>
-            /// <param name="args">Аргументы обработчика совпадений имен типов.</param>
-            /// <returns>Возвращает действие для обработки совпадающих типов.</returns>
-            public DuplicateTypeAction OnDuplicateTypeNamesFound(DuplicateTypeNamesHandlerArgs args) {
-                return DuplicateTypeAction.UseDestinationTypes;
-            }
         }
     }
 }

--- a/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
+++ b/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
@@ -375,24 +375,25 @@ namespace dosymep.Bim4Everyone.Templates {
             Document source,
             Document target,
             IEnumerable<RevitParam> revitParams) {
-            var paramsByCategory = new Dictionary<Category, List<ParameterElement>>();
-            foreach(RevitParam revitParam in revitParams.Where(item => !item.IsExistsParam(target))) {
-                Category category = GetRevitParamCategory(source, revitParam);
-                ParameterElement param = revitParam.GetRevitParamElement(source);
-                if(param == null) {
-                    throw new InvalidOperationException(
-                        $"Не удалось найти параметр '{revitParam.Name}' в шаблоне.");
-                }
+            var paramsByCategory = revitParams
+                .Where(revitParam => !revitParam.IsExistsParam(target))
+                .Select(revitParam => {
+                    ParameterElement param = revitParam.GetRevitParamElement(source);
+                    if(param == null) {
+                        throw new InvalidOperationException(
+                            $"Не удалось найти параметр '{revitParam.Name}' в шаблоне.");
+                    }
 
-                if(!paramsByCategory.TryGetValue(category, out List<ParameterElement> paramElements)) {
-                    paramElements = new List<ParameterElement>();
-                    paramsByCategory.Add(category, paramElements);
-                }
+                    return new {
+                        Category = GetRevitParamCategory(source, revitParam),
+                        Param = param
+                    };
+                })
+                .Where(item => item.Param != null)
+                .GroupBy(item => item.Category)
+                .ToArray();
 
-                paramElements.Add(param);
-            }
-
-            if(paramsByCategory.Count == 0) {
+            if(paramsByCategory.Length == 0) {
                 return Array.Empty<ViewSchedule>();
             } 
 
@@ -404,7 +405,7 @@ namespace dosymep.Bim4Everyone.Templates {
                         ViewSchedule viewSchedule = CreateParameterTransferSchedule(
                             source,
                             paramsGroup.Key,
-                            paramsGroup.Value);
+                            paramsGroup.Select(item => item.Param));
                         
                         transferSchedules.Add(viewSchedule);
                     } catch(Exception ex) {
@@ -426,16 +427,16 @@ namespace dosymep.Bim4Everyone.Templates {
         /// </summary>
         /// <param name="source">Файл шаблона</param>
         /// <param name="category">Категория</param>
-        /// <param name="paramElements">Объекты параметров из шаблона</param>
+        /// <param name="paramsElements">Параметры из шаблона</param>
         /// <returns></returns>
         private ViewSchedule CreateParameterTransferSchedule(
             Document source,
             Category category,
-            IEnumerable<ParameterElement> paramElements) {
+            IEnumerable<ParameterElement> paramsElements) {
             ViewSchedule viewSchedule = ViewSchedule.CreateSchedule(source, category.Id);
             viewSchedule.Name = $"{ParameterTransferScheduleNamePrefix}{Guid.NewGuid():N}";
 
-            foreach(ParameterElement param in paramElements) {
+            foreach(ParameterElement param in paramsElements) {
                 SchedulableField schedulableField = viewSchedule.Definition
                     .GetSchedulableFields()
                     .First(item => item.ParameterId == param.Id);
@@ -449,10 +450,10 @@ namespace dosymep.Bim4Everyone.Templates {
         /// Возвращает категорию, к которой привязан параметр в файле шаблона.
         /// </summary>
         /// <param name="source">Файл шаблона</param>
-        /// <param name="revitParam">Параметр</param>
+        /// <param name="param">Параметр</param>
         /// <returns></returns>
-        private static Category GetRevitParamCategory(Document source, RevitParam revitParam) {
-            (Definition Definition, Binding Binding) paramBinding = revitParam.GetParamBinding(source);
+        private static Category GetRevitParamCategory(Document source, RevitParam param) {
+            (Definition Definition, Binding Binding) paramBinding = param.GetParamBinding(source);
             if(!(paramBinding.Binding is ElementBinding elementBinding)) {
                 return null;
             }

--- a/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
+++ b/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
@@ -443,7 +443,7 @@ namespace dosymep.Bim4Everyone.Templates {
                     continue;
                 }
 
-                if(GetRevitSharedParamElement(target, revitParam) == null) {
+                if(!HasRevitElementParam(target, revitParam)) {
                     regularCopyParams.Add(revitParam);
                     continue;
                 }
@@ -458,21 +458,20 @@ namespace dosymep.Bim4Everyone.Templates {
         }
 
         /// <summary>
-        /// Возвращает элемент общего параметра напрямую из документа. GetRevitParamElement/IsExists не подойдут в нашем случае
-        /// т.к. работают через биндинги(GetSharedParamBinding в DocumentExtensions)
+        /// Проверяет, существует ли элемент параметра в документе.
         /// </summary>
         /// <param name="document">Документ.</param>
-        /// <param name="revitParam">Общий параметр.</param>
-        /// <returns>Возвращает элемент общего параметра.</returns>
-        private ParameterElement GetRevitSharedParamElement(Document document, RevitParam revitParam) {
+        /// <param name="revitParam">Параметр Revit.</param>
+        /// <returns>Возвращает true, если элемент параметра существует, иначе false.</returns>
+        private bool HasRevitElementParam(Document document, RevitParam revitParam) {
             if(!(revitParam is SharedParam sharedParam)) {
-                return null;
+                return false;
             }
 
             return new FilteredElementCollector(document)
                 .OfClass(typeof(SharedParameterElement))
                 .OfType<SharedParameterElement>()
-                .FirstOrDefault(item => item.GuidValue.Equals(sharedParam.Guid));
+                .Any(item => item.GuidValue.Equals(sharedParam.Guid));
         }
 
         /// <summary>

--- a/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
+++ b/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
@@ -386,11 +386,12 @@ namespace dosymep.Bim4Everyone.Templates {
 
                     return new {
                         Category = GetRevitParamCategory(source, revitParam),
+                        RevitParam = revitParam,
                         Param = param
                     };
                 })
                 .Where(item => item.Param != null)
-                .GroupBy(item => item.Category)
+                .GroupBy(item => item.Category.Id.GetIdValue())
                 .ToArray();
 
             if(paramsByCategory.Length == 0) {
@@ -400,20 +401,28 @@ namespace dosymep.Bim4Everyone.Templates {
             var transferSchedules = new List<ViewSchedule>();
 
             using(var transaction = source.StartTransaction("Создание временных спецификаций параметров")) {
+                Exception exception = null;
+                string paramName = null;
                 foreach(var paramsGroup in paramsByCategory) {
+                    Category category = paramsGroup.First().Category;
                     try {
                         ViewSchedule viewSchedule = CreateParamTransferSchedule(
                             source,
-                            paramsGroup.Key,
+                            category,
                             paramsGroup.Select(item => item.Param));
                         
                         transferSchedules.Add(viewSchedule);
                     } catch(Exception ex) {
-                        throw new InvalidOperationException(
-                            $"Не удалось подготовить временную спецификацию переноса для категории " +
-                            $"'{paramsGroup.Key.Name}' в шаблоне.",
-                            ex);
+                        exception = exception ?? ex;
+                        paramName = paramName ?? paramsGroup.First().RevitParam.Name;
                     }
+                }
+
+                if(exception != null && transferSchedules.Count == 0) {
+                    throw new InvalidOperationException(
+                        $"Не удалось подготовить временную спецификацию переноса для параметра " +
+                        $"'{paramName}' в шаблоне.",
+                        exception);
                 }
 
                 transaction.Commit();

--- a/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
+++ b/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
@@ -379,8 +379,9 @@ namespace dosymep.Bim4Everyone.Templates {
             foreach(RevitParam revitParam in revitParams.Where(item => !item.IsExistsParam(target))) {
                 Category category = GetRevitParamCategory(source, revitParam);
                 ParameterElement param = revitParam.GetRevitParamElement(source);
-                if(category == null || param == null) {
-                    continue;
+                if(param == null) {
+                    throw new InvalidOperationException(
+                        $"Не удалось найти параметр '{revitParam.Name}' в шаблоне.");
                 }
 
                 if(!paramsByCategory.TryGetValue(category, out List<ParameterElement> paramElements)) {

--- a/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
+++ b/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
@@ -375,46 +375,42 @@ namespace dosymep.Bim4Everyone.Templates {
             Document source,
             Document target,
             IEnumerable<RevitParam> revitParams) {
-            RevitParam[] missingParams = revitParams
-                .Where(item => !item.IsExistsParam(target))
-                .ToArray();
+            var paramsByCategory = new Dictionary<Category, List<ParameterElement>>();
+            foreach(RevitParam revitParam in revitParams.Where(item => !item.IsExistsParam(target))) {
+                Category category = GetRevitParamCategory(source, revitParam);
+                ParameterElement parameterElement = revitParam.GetRevitParamElement(source);
+                if(category == null || parameterElement == null) {
+                    continue;
+                }
 
-            if(missingParams.Length == 0) {
-                return Array.Empty<ViewSchedule>();
+                if(!paramsByCategory.TryGetValue(category, out List<ParameterElement> parameterElements)) {
+                    parameterElements = new List<ParameterElement>();
+                    paramsByCategory.Add(category, parameterElements);
+                }
+
+                parameterElements.Add(parameterElement);
             }
 
+            if(paramsByCategory.Count == 0) {
+                return Array.Empty<ViewSchedule>();
+            } 
+
             var transferSchedules = new List<ViewSchedule>();
-            var transferSchedulesByCategoryId = new Dictionary<long, ViewSchedule>();
 
             using(var transaction = source.StartTransaction("Создание временных спецификаций параметров")) {
-                foreach(RevitParam revitParam in missingParams) {
+                foreach(var paramsGroup in paramsByCategory) {
                     try {
-                        ParameterElement parameterElement = revitParam.GetRevitParamElement(source);
-                        if(parameterElement == null) {
-                            continue;
-                        }
-
                         ViewSchedule viewSchedule = CreateParameterTransferSchedule(
                             source,
-                            transferSchedulesByCategoryId,
-                            revitParam,
-                            parameterElement);
+                            paramsGroup.Key,
+                            paramsGroup.Value);
                         
-                        if(viewSchedule != null
-                           && !transferSchedules.Any(item => item.Id == viewSchedule.Id)) {
-                            transferSchedules.Add(viewSchedule);
-                        }
-
-                        if(viewSchedule == null) {
-                            _loggerService.Warning(
-                                "Не удалось создать временную спецификацию переноса для параметра {@revitParam} в шаблоне.",
-                                revitParam);
-                        }
+                        transferSchedules.Add(viewSchedule);
                     } catch(Exception ex) {
                         _loggerService.Warning(
                             ex,
-                            "Не удалось подготовить временную спецификацию переноса для параметра {@revitParam} в шаблоне.",
-                            revitParam);
+                            "Не удалось подготовить временную спецификацию переноса для категории {category} в шаблоне.",
+                            paramsGroup.Key.Name);
                     }
                 }
 
@@ -425,124 +421,44 @@ namespace dosymep.Bim4Everyone.Templates {
         }
 
         /// <summary>
-        /// Создает временную спецификацию переноса для параметра в шаблоне или использует одну из ранее созданных.
+        /// Создает временную спецификацию переноса для параметров в шаблоне.
         /// </summary>
         /// <param name="source">Файл шаблона</param>
-        /// <param name="transferSchedulesByCategoryId">Словарь ранее созданных спецификаций</param>
-        /// <param name="revitParam">Параметр</param>
-        /// <param name="parameterElement">Объект параметра из шаблона</param>
+        /// <param name="category">Категория</param>
+        /// <param name="parameterElements">Объекты параметров из шаблона</param>
         /// <returns></returns>
         private ViewSchedule CreateParameterTransferSchedule(
             Document source,
-            IDictionary<long, ViewSchedule> transferSchedulesByCategoryId,
-            RevitParam revitParam,
-            ParameterElement parameterElement) {
-            foreach(Category category in GetRevitParamCategories(source, revitParam)) {
-                ViewSchedule viewSchedule = GetOrCreateParameterTransferSchedule(
-                    source,
-                    transferSchedulesByCategoryId,
-                    category);
-                if(viewSchedule == null) {
-                    continue;
-                }
+            Category category,
+            IEnumerable<ParameterElement> parameterElements) {
+            ViewSchedule viewSchedule = ViewSchedule.CreateSchedule(source, category.Id);
+            viewSchedule.Name = $"{ParameterTransferScheduleNamePrefix}{Guid.NewGuid():N}";
 
-                if(TryAddParameterTransferField(viewSchedule, parameterElement)) {
-                    return viewSchedule;
-                }
+            foreach(ParameterElement parameterElement in parameterElements) {
+                SchedulableField schedulableField = viewSchedule.Definition
+                    .GetSchedulableFields()
+                    .First(item => item.ParameterId == parameterElement.Id);
+                viewSchedule.Definition.AddField(schedulableField);
             }
 
-            return null;
+            return viewSchedule;
         }
 
         /// <summary>
-        /// Создает новую трансферную спецификацию или возвращает ранее созданную для текущей категории.
-        /// </summary>
-        /// <param name="source">Файл шаблона</param>
-        /// <param name="transferSchedulesByCategoryId">Словарь с трансферными спецификацями</param>
-        /// <param name="category">Категория</param>
-        /// <returns></returns>
-        private ViewSchedule GetOrCreateParameterTransferSchedule(
-            Document source,
-            IDictionary<long, ViewSchedule> transferSchedulesByCategoryId,
-            Category category) {
-            long categoryId = category.Id.GetIdValue();
-            if(transferSchedulesByCategoryId.TryGetValue(categoryId, out ViewSchedule viewSchedule)) {
-                return viewSchedule;
-            }
-
-            try {
-                viewSchedule = ViewSchedule.CreateSchedule(source, category.Id);
-                viewSchedule.Name = $"{ParameterTransferScheduleNamePrefix}{Guid.NewGuid():N}";
-                transferSchedulesByCategoryId.Add(categoryId, viewSchedule);
-
-                return viewSchedule;
-            } catch(Exception ex) {
-                transferSchedulesByCategoryId.Add(categoryId, null);
-                _loggerService.Warning(
-                    ex,
-                    "Не удалось создать временную спецификацию переноса для категории {category} в шаблоне.",
-                    category.Name);
-
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Возвращает категории, к которым привязан параметр в файле шаблона.
+        /// Возвращает категорию, к которой привязан параметр в файле шаблона.
         /// </summary>
         /// <param name="source">Файл шаблона</param>
         /// <param name="revitParam">Параметр</param>
         /// <returns></returns>
-        private static IEnumerable<Category> GetRevitParamCategories(Document source, RevitParam revitParam) {
+        private static Category GetRevitParamCategory(Document source, RevitParam revitParam) {
             (Definition Definition, Binding Binding) paramBinding = revitParam.GetParamBinding(source);
             if(!(paramBinding.Binding is ElementBinding elementBinding)) {
-                yield break;
+                return null;
             }
 
-            foreach(Category category in elementBinding.Categories) {
-                if(category != null) {
-                    yield return category;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Пробует добавить в трансферную спецификацию требуемый параметр. Если в ранее созданной таблице уже есть такой параметр, возвращает True и не добавляет.
-        /// </summary>
-        /// <param name="viewSchedule">Таблица</param>
-        /// <param name="parameterElement">Объект параметра из шаблона</param>
-        /// <returns></returns>
-        private static bool TryAddParameterTransferField(ViewSchedule viewSchedule, ParameterElement parameterElement) {
-            if(IsParameterTransferFieldExists(viewSchedule, parameterElement)) {
-                return true;
-            }
-
-            SchedulableField schedulableField = viewSchedule.Definition
-                .GetSchedulableFields()
-                .FirstOrDefault(item => item.ParameterId == parameterElement.Id);
-            if(schedulableField == null) {
-                return false;
-            }
-
-            try {
-                viewSchedule.Definition.AddField(schedulableField);
-                return true;
-            } catch(Exception) {
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Для ранее созданной таблицы проверяет существует ли в ней уже требуемый параметр.
-        /// </summary>
-        /// <param name="viewSchedule">Таблица</param>
-        /// <param name="parameterElement">Объект параметра из шаблона</param>
-        /// <returns></returns>
-        private static bool IsParameterTransferFieldExists(ViewSchedule viewSchedule, ParameterElement parameterElement) {
-            ScheduleDefinition definition = viewSchedule.Definition;
-            return definition.GetFieldOrder()
-                .Select(item => definition.GetField(item))
-                .Any(item => item.ParameterId == parameterElement.Id);
+            return elementBinding.Categories
+                .OfType<Category>()
+                .FirstOrDefault();
         }
 
         #endregion

--- a/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
+++ b/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 
-using Autodesk.Revit.ApplicationServices;
 using Autodesk.Revit.DB;
 
 using dosymep.Bim4Everyone;
@@ -15,11 +15,15 @@ using dosymep.Bim4Everyone.SimpleServices;
 using dosymep.Revit;
 using dosymep.SimpleServices;
 
+using Application = Autodesk.Revit.ApplicationServices.Application;
+
 namespace dosymep.Bim4Everyone.Templates {
     /// <summary>
     /// Класс по копирование параметров проекта.
     /// </summary>
     public class ProjectParameters {
+        private const string ParamTransferScheduleNamePrefix = "BIM4E_PARAM_TRANSFER_";
+
         private readonly ILoggerService _loggerService;
 
         /// <summary>
@@ -304,7 +308,12 @@ namespace dosymep.Bim4Everyone.Templates {
                 return false;
             }
 
-            ICollection<ElementId> copiedElements = ElementTransformUtils.CopyElements(source, new[] { viewSchedule.Id }, target, Transform.Identity, new CopyPasteOptions());
+            ICollection<ElementId> copiedElements = ElementTransformUtils.CopyElements(
+                source,
+                new[] { viewSchedule.Id },
+                target,
+                Transform.Identity,
+                CreateCopyPasteOptions());
             if(removeSchedule) {
                 // Удаляем скопированный вид,
                 // так как он нужен был для переноса параметра
@@ -332,7 +341,12 @@ namespace dosymep.Bim4Everyone.Templates {
                 return false;
             }
 
-            ICollection<ElementId> copiedElements = ElementTransformUtils.CopyElements(source, viewSchedules.Select(item => item.Id).ToArray(), target, Transform.Identity, new CopyPasteOptions());
+            ICollection<ElementId> copiedElements = ElementTransformUtils.CopyElements(
+                source,
+                viewSchedules.Select(item => item.Id).ToArray(),
+                target,
+                Transform.Identity,
+                CreateCopyPasteOptions());
             if(removeSchedule) {
                 // Удаляем скопированные виды,
                 // так как они нужны были для переноса параметра
@@ -367,19 +381,152 @@ namespace dosymep.Bim4Everyone.Templates {
                 source.Close(false);
             }
         }
+        
 
-        private void RevitParamsCopy(Document source, Document target, IEnumerable<RevitParam> revitParams) {
-            ElementId[] sourceParamElementIds = revitParams
-                .Where(item => !item.IsExistsParam(target))
-                .Select(item => item.GetRevitParamElement(source))
-                .Where(item => item != null)
-                .Select(item => item.Id)
-                .ToArray();
-
-            if(sourceParamElementIds.Length > 0) {
-                ElementTransformUtils.CopyElements(source, sourceParamElementIds, target,
+        private void RevitParamsCopy(
+            Document source,
+            Document target,
+            IEnumerable<RevitParam> revitParams)
+        {
+            (ICollection<RevitParam> missingParams, ICollection<RevitParam> paramsWithoutBinding)
+                = SplitRevitParamsByBinding(target, revitParams);
+            
+            ParameterElement[] missingParamsElements = GetRevitParamElements(source, missingParams);
+            ParameterElement[] paramsWithoutBindingElements = GetRevitParamElements(source, paramsWithoutBinding);
+            
+            if(missingParamsElements.Length > 0) {
+                ElementTransformUtils.CopyElements(
+                    source,
+                    missingParamsElements.Select(item => item.Id).ToArray(),
+                    target,
                     Transform.Identity,
                     new CopyPasteOptions());
+            }
+            
+            if(paramsWithoutBindingElements.Length > 0) {
+                CopyParamsByMultiCategorySchedule(
+                    source,
+                    target,
+                    paramsWithoutBindingElements);
+            }
+        }
+
+        /// <summary>
+        /// Возвращает элементы параметров из документа.
+        /// </summary>
+        /// <param name="source">Документ с параметрами.</param>
+        /// <param name="revitParams">Параметры.</param>
+        /// <returns>Возвращает элементы параметров.</returns>
+        private static ParameterElement[] GetRevitParamElements(Document source, IEnumerable<RevitParam> revitParams) {
+            return revitParams
+                .Select(item => item.GetRevitParamElement(source))
+                .Where(item => item != null)
+                .ToArray();
+        }
+
+        /// <summary>
+        /// Разделяет параметры на отсутствующие в документе и существующие без привязки к категориям.
+        /// </summary>
+        /// <param name="target">Целевой документ.</param>
+        /// <param name="revitParams">Параметры, которые нужно разделить.</param>
+        /// <returns>Возвращает отсутствующие параметры и параметры без привязки.</returns>
+        private static (
+            ICollection<RevitParam> MissingParams,
+            ICollection<RevitParam> ParamsWithoutBinding) SplitRevitParamsByBinding(
+                Document target,
+                IEnumerable<RevitParam> revitParams) {
+            var missingParams = new List<RevitParam>();
+            var paramsWithoutBinding = new List<RevitParam>();
+
+            foreach(RevitParam revitParam in revitParams) {
+                if(GetRevitSharedParamElement(target, revitParam) == null) {
+                    missingParams.Add(revitParam);
+                    continue;
+                }
+
+                (Definition Definition, Binding Binding) paramBinding = revitParam.GetParamBinding(target);
+                if(paramBinding.Definition == null || paramBinding.Binding == null) {
+                    paramsWithoutBinding.Add(revitParam);
+                }
+            }
+
+            return (missingParams, paramsWithoutBinding);
+        }
+
+        /// <summary>
+        /// Возвращает элемент общего параметра напрямую из документа. GetRevitParamElement/IsExists не подойдут в нашем случае
+        /// т.к. работают через биндинги
+        /// </summary>
+        /// <param name="document">Документ.</param>
+        /// <param name="revitParam">Общий параметр.</param>
+        /// <returns>Возвращает элемент общего параметра.</returns>
+        private static ParameterElement GetRevitSharedParamElement(Document document, RevitParam revitParam) {
+            if(!(revitParam is SharedParam sharedParam)) {
+                return null;
+            }
+
+            return new FilteredElementCollector(document)
+                .OfClass(typeof(SharedParameterElement))
+                .OfType<SharedParameterElement>()
+                .FirstOrDefault(item => item.GuidValue.Equals(sharedParam.Guid));
+        }
+
+        /// <summary>
+        /// Копирует параметры через временную мультикатегорийную спецификацию.
+        /// </summary>
+        /// <param name="source">Файл шаблона.</param>
+        /// <param name="target">Целевой документ.</param>
+        /// <param name="paramsElements">Параметры из шаблона.</param>
+        private static void CopyParamsByMultiCategorySchedule(
+            Document source,
+            Document target,
+            IEnumerable<ParameterElement> paramsElements) {
+            ViewSchedule viewSchedule = null;
+
+            using(var transaction = source.StartTransaction("Создание временной спецификации параметров")) {
+                viewSchedule = ViewSchedule.CreateSchedule(source, ElementId.InvalidElementId);
+                viewSchedule.Name = $"{ParamTransferScheduleNamePrefix}{Guid.NewGuid():N}";
+
+                foreach(ParameterElement param in paramsElements) {
+                    SchedulableField schedulableField = viewSchedule.Definition
+                        .GetSchedulableFields()
+                        .FirstOrDefault(item => item.ParameterId == param.Id);
+                    if(schedulableField == null) {
+                        throw new InvalidOperationException(
+                            $"Не удалось добавить параметр '{param.Name}' во временную спецификацию.");
+                    }
+
+                    viewSchedule.Definition.AddField(schedulableField);
+                }
+
+                transaction.Commit();
+            }
+
+            CopyViewSchedule(source, target, true, viewSchedule);
+        }
+
+        /// <summary>
+        /// Создает настройки копирования элементов.
+        /// </summary>
+        /// <returns>Возвращает настройки копирования элементов.</returns>
+        private static CopyPasteOptions CreateCopyPasteOptions() {
+            var copyPasteOptions = new CopyPasteOptions();
+            copyPasteOptions.SetDuplicateTypeNamesHandler(new UseDestinationDuplicateTypeNamesHandler());
+
+            return copyPasteOptions;
+        }
+
+        /// <summary>
+        /// Обработчик совпадений имен типов при копировании элементов.
+        /// </summary>
+        private class UseDestinationDuplicateTypeNamesHandler : IDuplicateTypeNamesHandler {
+            /// <summary>
+            /// Обрабатывает совпадения имен типов при копировании элементов.
+            /// </summary>
+            /// <param name="args">Аргументы обработчика совпадений имен типов.</param>
+            /// <returns>Возвращает действие для обработки совпадающих типов.</returns>
+            public DuplicateTypeAction OnDuplicateTypeNamesFound(DuplicateTypeNamesHandlerArgs args) {
+                return DuplicateTypeAction.UseDestinationTypes;
             }
         }
 

--- a/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
+++ b/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
@@ -387,16 +387,16 @@ namespace dosymep.Bim4Everyone.Templates {
             Document target,
             IEnumerable<RevitParam> revitParams)
         {
-            (ICollection<RevitParam> missingParams, ICollection<RevitParam> paramsWithoutBinding)
+            (ICollection<RevitParam> regularCopyParams, ICollection<RevitParam> paramsWithoutBinding)
                 = SplitRevitParamsByBinding(target, revitParams);
             
-            ParameterElement[] missingParamsElements = GetRevitParamElements(source, missingParams);
+            ParameterElement[] regularCopyParamsElements = GetRevitParamElements(source, regularCopyParams);
             ParameterElement[] paramsWithoutBindingElements = GetRevitParamElements(source, paramsWithoutBinding);
             
-            if(missingParamsElements.Length > 0) {
+            if(regularCopyParamsElements.Length > 0) {
                 ElementTransformUtils.CopyElements(
                     source,
-                    missingParamsElements.Select(item => item.Id).ToArray(),
+                    regularCopyParamsElements.Select(item => item.Id).ToArray(),
                     target,
                     Transform.Identity,
                     new CopyPasteOptions());
@@ -424,22 +424,27 @@ namespace dosymep.Bim4Everyone.Templates {
         }
 
         /// <summary>
-        /// Разделяет параметры на отсутствующие в документе и существующие без привязки к категориям.
+        /// Разделяет параметры на параметры для обычного копирования и общие параметры без привязки к категориям.
         /// </summary>
         /// <param name="target">Целевой документ.</param>
         /// <param name="revitParams">Параметры, которые нужно разделить.</param>
-        /// <returns>Возвращает отсутствующие параметры и параметры без привязки.</returns>
+        /// <returns>Возвращает параметры для обычного копирования и параметры без привязки.</returns>
         private (
-            ICollection<RevitParam> MissingParams,
+            ICollection<RevitParam> RegularCopyParams,
             ICollection<RevitParam> ParamsWithoutBinding) SplitRevitParamsByBinding(
                 Document target,
                 IEnumerable<RevitParam> revitParams) {
-            var missingParams = new List<RevitParam>();
+            var regularCopyParams = new List<RevitParam>();
             var paramsWithoutBinding = new List<RevitParam>();
 
             foreach(RevitParam revitParam in revitParams) {
+                if(!(revitParam is SharedParam)) {
+                    regularCopyParams.Add(revitParam);
+                    continue;
+                }
+
                 if(GetRevitSharedParamElement(target, revitParam) == null) {
-                    missingParams.Add(revitParam);
+                    regularCopyParams.Add(revitParam);
                     continue;
                 }
 
@@ -449,7 +454,7 @@ namespace dosymep.Bim4Everyone.Templates {
                 }
             }
 
-            return (missingParams, paramsWithoutBinding);
+            return (regularCopyParams, paramsWithoutBinding);
         }
 
         /// <summary>
@@ -508,7 +513,7 @@ namespace dosymep.Bim4Everyone.Templates {
         /// Создает настройки копирования элементов.
         /// </summary>
         /// <returns>Возвращает настройки копирования элементов.</returns>
-        private CopyPasteOptions CreateCopyPasteOptions() {
+        private static CopyPasteOptions CreateCopyPasteOptions() {
             var copyPasteOptions = new CopyPasteOptions();
             copyPasteOptions.SetDuplicateTypeNamesHandler(new UseDestinationDuplicateTypeNamesHandler());
 

--- a/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
+++ b/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
@@ -409,10 +409,10 @@ namespace dosymep.Bim4Everyone.Templates {
                         
                         transferSchedules.Add(viewSchedule);
                     } catch(Exception ex) {
-                        _loggerService.Warning(
-                            ex,
-                            "Не удалось подготовить временную спецификацию переноса для категории {category} в шаблоне.",
-                            paramsGroup.Key.Name);
+                        throw new InvalidOperationException(
+                            $"Не удалось подготовить временную спецификацию переноса для категории " +
+                            $"'{paramsGroup.Key.Name}' в шаблоне.",
+                            ex);
                     }
                 }
 

--- a/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
+++ b/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
@@ -20,7 +20,7 @@ namespace dosymep.Bim4Everyone.Templates {
     /// Класс по копирование параметров проекта.
     /// </summary>
     public class ProjectParameters {
-        private const string ParameterTransferScheduleNamePrefix = "BIM4E_PARAM_TRANSFER_";
+        private const string ParamTransferScheduleNamePrefix = "BIM4E_PARAM_TRANSFER_";
 
         private readonly ILoggerService _loggerService;
 
@@ -371,7 +371,7 @@ namespace dosymep.Bim4Everyone.Templates {
         /// <param name="target">Целевой документ</param>
         /// <param name="revitParams">Параметры, которые нужно проверить на наличие в целевом документе</param>
         /// <returns></returns>
-        private ICollection<ViewSchedule> CreateParameterTransferSchedules(
+        private ICollection<ViewSchedule> CreateParamTransferSchedules(
             Document source,
             Document target,
             IEnumerable<RevitParam> revitParams) {
@@ -402,7 +402,7 @@ namespace dosymep.Bim4Everyone.Templates {
             using(var transaction = source.StartTransaction("Создание временных спецификаций параметров")) {
                 foreach(var paramsGroup in paramsByCategory) {
                     try {
-                        ViewSchedule viewSchedule = CreateParameterTransferSchedule(
+                        ViewSchedule viewSchedule = CreateParamTransferSchedule(
                             source,
                             paramsGroup.Key,
                             paramsGroup.Select(item => item.Param));
@@ -429,12 +429,12 @@ namespace dosymep.Bim4Everyone.Templates {
         /// <param name="category">Категория</param>
         /// <param name="paramsElements">Параметры из шаблона</param>
         /// <returns></returns>
-        private ViewSchedule CreateParameterTransferSchedule(
+        private ViewSchedule CreateParamTransferSchedule(
             Document source,
             Category category,
             IEnumerable<ParameterElement> paramsElements) {
             ViewSchedule viewSchedule = ViewSchedule.CreateSchedule(source, category.Id);
-            viewSchedule.Name = $"{ParameterTransferScheduleNamePrefix}{Guid.NewGuid():N}";
+            viewSchedule.Name = $"{ParamTransferScheduleNamePrefix}{Guid.NewGuid():N}";
 
             foreach(ParameterElement param in paramsElements) {
                 SchedulableField schedulableField = viewSchedule.Definition
@@ -468,7 +468,7 @@ namespace dosymep.Bim4Everyone.Templates {
         private void RevitParamsCopy(Document target, IEnumerable<RevitParam> revitParams) {
             Document source = Application.OpenDocumentFile(ModuleEnvironment.ParametersTemplatePath);
             try {
-                ICollection<ViewSchedule> transferSchedules = CreateParameterTransferSchedules(source, target, revitParams);
+                ICollection<ViewSchedule> transferSchedules = CreateParamTransferSchedules(source, target, revitParams);
 
                 using(var transaction = target.StartTransaction("Настройка параметров")) {
                     CopyViewSchedules(source, target, true, transferSchedules);

--- a/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
+++ b/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
@@ -459,7 +459,7 @@ namespace dosymep.Bim4Everyone.Templates {
 
         /// <summary>
         /// Возвращает элемент общего параметра напрямую из документа. GetRevitParamElement/IsExists не подойдут в нашем случае
-        /// т.к. работают через биндинги
+        /// т.к. работают через биндинги(GetSharedParamBinding в DocumentExtensions)
         /// </summary>
         /// <param name="document">Документ.</param>
         /// <param name="revitParam">Общий параметр.</param>


### PR DESCRIPTION
Изменен механизм настройки параметров проекта из шаблона в активный документ.

Теперь для параметров используется дополнительный перенос через временные спецификации:
1) в шаблоне создается временная спецификация по одной из категорий, назначенных параметру
2) в спецификацию добавляется поле нужного параметра
3) спецификация копируется в целевой документ и сразу удаляется
4) после появления binding запускается текущая синхронизация категорий параметра

Также подавлен системный диалог Revit о совпадении имен типов при копировании элементов(возникает при переносе спецификаций)