### PR TITLE
ProjectParameters: Дублирование параметров проекта

### DIFF
--- a/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
+++ b/src/dosymep.Bim4Everyone/Templates/ProjectParameters.cs
@@ -66,7 +66,9 @@ public class ProjectParameters {
         (ICollection<RevitParam> regularCopyParams, ICollection<RevitParam> paramsWithoutBinding)
             = SplitRevitParamsByBinding(target, revitParams);
 
-        ParameterElement[] regularCopyParamsElements = GetRevitParamElements(source, regularCopyParams);
+        ParameterElement[] regularCopyParamsElements = GetRevitParamElements(
+            source,
+            regularCopyParams.Where(item => !item.IsExistsParam(target)));
         ParameterElement[] paramsWithoutBindingElements = GetRevitParamElements(source, paramsWithoutBinding);
 
         if(regularCopyParamsElements.Length > 0) {


### PR DESCRIPTION
Возвращение проверки !item.IsExistsParam(target) для regularCopyParams. Ранее она фильтровала дублирование параметров проекта, сейчас без нее они каждый раз падают в список regularCopyParamsElements по логике SplitRevitParamsByBinding и копируются заново